### PR TITLE
fix(map): use canPlace var instead of hard-coded

### DIFF
--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -465,7 +465,9 @@ export class OLMap {
       const [lng, lat] = transform(view.getCenter()!, 'EPSG:3857', 'EPSG:4326')
 
       if (handler.onMoved) {
-        handler.onMoved([lng, lat, range, zoom], true)
+        const { width, height } = this.mapDom.getBoundingClientRect()
+        const canPlace = await this.canPlaceFactory([width / 2, height / 2])
+        handler.onMoved([lng, lat, range, zoom], canPlace)
       }
     }
 


### PR DESCRIPTION
We already have the default value of canPlaceFactory so we do not need
to hard code canPlace. The hard-coded flag may make others confused when
maintaining the code in the future.

Issue: #15
PR: #51