### PR TITLE
Rename get and create factories api to ohshown

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,7 +22,7 @@ export type UploadedImages = {
 
 export async function getFactories (range: number, lng: number, lat: number): Promise<FactoriesResponse> {
   try {
-    const { data } = await instance.get(`/factories?range=${range}&lng=${lng}&lat=${lat}`)
+    const { data } = await instance.get(`/ohshown-events?range=${range}&lng=${lng}&lat=${lat}`)
     return data
   } catch (err) {
     console.error(err)
@@ -130,7 +130,7 @@ export async function updateFactoryImages (factoryId: string, files: FileList, {
 
 export async function createFactory (factory: FactoryPostData): Promise<FactoryData> {
   try {
-    const { data }: { data: FactoryData } = await instance.post('/factories', JSON.stringify(factory))
+    const { data }: { data: FactoryData } = await instance.post('/ohshown-events', JSON.stringify(factory))
 
     return data
   } catch (err) {


### PR DESCRIPTION
# Why
Sync with Backend API endpoint path change https://github.com/tai271828/disfactory-backend/pull/46#issuecomment-1066559298
# What
Call API endpoint `/ohshow-events` instead of `/factories` when get and create ohshown-events
# How
Modify `index.ts` for the related GET and POST endpoint.
# Test
Test to hit new Backend API endpoints, looks good.
Not sure if we need more tests for this.
![image](https://user-images.githubusercontent.com/94128872/158210476-822424a8-d746-4a63-ba70-9d49bcafa0c8.png)