### PR TITLE
docs(README): use ohshown as the project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Disfactory frontend
+# OH!SHOWN Frontend
 
-- Staging Server: https://dev.disfactory.tw (latest `master` branch)
-- Production server: https://disfactory.tw (`production` branch)
+`OH!SHOWN 野生動物出沒痕跡通報系統` 的前端。搭配對應的 [後端](https://github.com/tai271828/disfactory-backend) 以呈現通報資料。
+
+本專案為 [Disfactory 違章工廠舉報系統](https://github.com/Disfactory) 分支，感謝相關社群與人士分享與指教。
+
+分支目前還處於基於 [Disfactory 違章工廠舉報系統](https://github.com/Disfactory) 程式碼重構施工階段中。
+文件、程式碼與單元測試皆尚未更新完畢；歡迎大家直接送重構用程式碼、補丁與 Pull Request 。
 
 ## Project setup
 


### PR DESCRIPTION
After changing the project name, we can create an organization page like [Disfactory](https://github.com/Disfactory) to collect our repositories.

I don't think we need to wait until the beta is ready. We can do this earlier if the project name and status elaborated clearly and explicitly.

Benefit:
A Github organization page like [Disfactory](https://github.com/Disfactory) may help us call for awareness from the community.

Additional context:
We may adapt [diataxis](https://diataxis.fr/) document style in the future.